### PR TITLE
Update GameWatchArguments.vb

### DIFF
--- a/NHLGames/Objects/GameWatchArguments.vb
+++ b/NHLGames/Objects/GameWatchArguments.vb
@@ -89,7 +89,7 @@ Namespace Objects
             Dim title = $"{GameTitle} - {Stream.Network} - {Quality.ToString()}"
             Select Case PlayerType
                 Case PlayerTypeEnum.Mpv
-                    args &= $"--force-window=immediate --title """"{title}"""" --user-agent=User-Agent=""""{Common.UserAgent}"""""
+                    args &= $"--force-window=immediate --title=""""{title}"""" --user-agent=User-Agent=""""{Common.UserAgent}"""""
                 Case PlayerTypeEnum.Vlc
                     args &= $"--meta-title """"{title}"""" "
                     If IsProxyNecessary() Then args &= $"{VlcHttpProxyArgs()} "


### PR DESCRIPTION
MPV changed the way it handles 2 dash parameters, now = is mandatory

https://mpv.io/manual/master/#legacy-option-syntax